### PR TITLE
Update Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,4 +45,4 @@ group :development do
   gem 'spring'
 end
 
-gem 'shopify_app'
+gem 'shopify_app', '6.4.2'


### PR DESCRIPTION
Shopify_app version was not specified causing the latest gem to be installed. Version 7 of the Shopify_app gem is not compatible with this codebase. It causes this error: block in <top (required)>': undefined method `redirect_uri'.
